### PR TITLE
Add: manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,5 +9,6 @@ jobs:
   release:
     uses: nzbgetcom/nzbget-extensions/.github/workflows/extension-release.yml@main
     with:
-      release-file-list: Logger.py
+      release-file-list: main.py manifest.json
       release-file-name: logger
+      release-dir: logger

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **Note:** This script is compatible with NZBGet v23 and above.
+For older versions of NZBGet please use [v1.0](https://github.com/nzbgetcom/Extension-Logger/releases/tag/v1.0) release.
+
 # Logger
 Logger [script](https://nzbget.com/documentation/post-processing-scripts/) for [NZBGet](https://nzbget.com).
 
@@ -5,4 +8,4 @@ This script saves the download and post-processing log of nzb-file into file _nz
 
 Author: Andrey Prygunkov <hugbug@users.sourceforge.net>
 
-> **Note:** This script is compatible with python 3.8.x and above.
+> **Note:** This script requires Python to be installed on your system.

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Logger post-processing script for NZBGet
 #
@@ -15,23 +14,8 @@
 # GNU General Public License for more details.
 # 
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-
-
-##############################################################################
-### NZBGET POST-PROCESSING SCRIPT                                          ###
-
-# Save nzb log into a file.
-#
-# This script saves the download and post-processing log of nzb-file
-# into file _nzblog.txt in the destination directory.
-#
-# NOTE: This script requires Python to be installed on your system.
-
-### NZBGET POST-PROCESSING SCRIPT                                          ###
-##############################################################################
-
 
 import os
 import sys

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,22 @@
+{
+    "main": "main.py",
+    "name": "Logger",
+    "homepage": "",
+    "kind": "POST-PROCESSING",
+    "displayName": "Logger",
+    "version": "1.0.0",
+    "author": "Andrey Prygunkov",
+    "license": "GNU",
+    "about": "Save nzb log into a file.",
+    "queueEvents": "",
+    "requirements": [
+        "This script requires Python to be installed on your system."
+    ],
+    "description": [
+        "This script saves the download and post-processing log of nzb-file",
+        "into file _nzblog.txt in the destination directory."
+    ],
+    "options": [],
+    "commands": [],
+    "taskTime": ""
+}


### PR DESCRIPTION
- migration from a file header config definition to a manifest.json-based configuration
- works with NZBGet v23 and above
- no longer works with NZBGet v22 and below